### PR TITLE
Sign: Do not allow edits by any player except the one who placed it, …

### DIFF
--- a/src/pocketmine/block/SignPost.php
+++ b/src/pocketmine/block/SignPost.php
@@ -68,7 +68,10 @@ class SignPost extends Transparent{
 				$this->getLevelNonNull()->setBlock($blockReplace, BlockFactory::get(Block::WALL_SIGN, $this->meta), true);
 			}
 
-			Tile::createTile(Tile::SIGN, $this->getLevelNonNull(), TileSign::createNBT($this, $face, $item, $player));
+			$sign = Tile::createTile(Tile::SIGN, $this->getLevelNonNull(), TileSign::createNBT($this, $face, $item, $player));
+			if($player !== null && $sign instanceof TileSign){
+				$sign->setEditorEntityRuntimeId($player->getId());
+			}
 
 			return true;
 		}


### PR DESCRIPTION
original message from pmmp/stable:"
…and only while that player is online

signs now become finalized if:
- the player quits and rejoins (because the entity runtime ID of the player will not be the same)
- the chunk is unloaded and reloaded (because the tagged entity runtime ID is not saved).

closes #4198
"
Note: this merge https://github.com/pmmp/PocketMine-MP/commit/c47ecb55c0a4a2492f1288736ffe87795d5b538a